### PR TITLE
Add devtools server to example

### DIFF
--- a/boilerplate/app.mozbuild
+++ b/boilerplate/app.mozbuild
@@ -6,12 +6,5 @@
 include('/toolkit/toolkit.mozbuild')
 
 DIRS += [
-  "/newapp"
+    "/newapp"
 ]
-
-#if CONFIG["MOZ_EXTENSIONS"]:
-#    DIRS += ["/%s/extensions" % CONFIG["mozreltopsrcdir"]]
-
-#DIRS += [
-#    '/%s' % CONFIG['MOZ_BRANDING_DIRECTORY'],
-#]

--- a/boilerplate/frontend/app-preferences.js
+++ b/boilerplate/frontend/app-preferences.js
@@ -6,3 +6,5 @@ pref("javascript.options.showInConsole", true);
 pref("javascript.options.strict", true);
 pref("nglayout.debug.disable_xul_cache", true);
 pref("nglayout.debug.disable_xul_fastload", true);
+
+pref("devtools.debugger.server-port", 40291);

--- a/boilerplate/frontend/content/main.js
+++ b/boilerplate/frontend/content/main.js
@@ -1,3 +1,22 @@
+const { XPCOMUtils } = ChromeUtils.importESModule(
+  "resource://gre/modules/XPCOMUtils.sys.mjs"
+);
+
+XPCOMUtils.defineLazyModuleGetters(this, {
+  DevtoolsServer: "resource:///modules/DevtoolsServer.jsm",
+});
+
 function showMore() {
   document.getElementById("more-text").hidden = false;
+}
+
+function startDevtools() {
+  const devtools = new DevtoolsServer();
+  devtools.start();
+
+  const instructions = document.getElementById("devtools-instructions");
+  instructions.hidden = false;
+
+  const portEl = document.getElementById("devtools-port");
+  portEl.innerText = devtools.port;
 }

--- a/boilerplate/frontend/content/main.js
+++ b/boilerplate/frontend/content/main.js
@@ -3,7 +3,7 @@ const { XPCOMUtils } = ChromeUtils.importESModule(
 );
 
 XPCOMUtils.defineLazyModuleGetters(this, {
-  DevtoolsServer: "resource:///modules/DevtoolsServer.jsm",
+  DevtoolsServer: "resource://app/modules/DevtoolsServer.jsm",
 });
 
 function showMore() {

--- a/boilerplate/frontend/content/main.js
+++ b/boilerplate/frontend/content/main.js
@@ -11,7 +11,7 @@ function showMore() {
 }
 
 function startDevtools() {
-  const devtools = new DevtoolsServer();
+  const devtools = DevtoolsServer.get();
   devtools.start();
 
   const instructions = document.getElementById("devtools-instructions");

--- a/boilerplate/frontend/content/main.xhtml
+++ b/boilerplate/frontend/content/main.xhtml
@@ -1,32 +1,59 @@
 <?xml version="1.0"?>
 
 <?xml-stylesheet href="chrome://global/skin/" type="text/css"?>
-<html id="main"
-      xmlns:html="http://www.w3.org/1999/xhtml"
-      xmlns:xul="http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul"
-      xmlns="http://www.w3.org/1999/xhtml"
-      title="MyApp"
-      width="300"
-      height="300"
+<html
+  id="main"
+  xmlns:html="http://www.w3.org/1999/xhtml"
+  xmlns:xul="http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul"
+  xmlns="http://www.w3.org/1999/xhtml"
+  title="MyApp"
+  width="300"
+  height="300"
 >
-<head>
-  <script>
-    const { Services } = ChromeUtils.import(
-      "resource://gre/modules/Services.jsm"
-    );
+  <head>
+    <script>
+      const { Services } = ChromeUtils.import(
+        "resource://gre/modules/Services.jsm"
+      );
 
-    Services.scriptloader.loadSubScript(
-      "chrome://newapp/content/main.js",
-      this
-    );
-  </script>
-</head>
+      Services.scriptloader.loadSubScript(
+        "chrome://newapp/content/main.js",
+        this
+      );
+    </script>
+  </head>
 
-<html:body xmlns="http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul">
-  <description>Hello World</description>
-  <separator/>
-  <button id="show-more" label="More >>" oncommand="showMore()" />
-  <separator/>
-  <description id="more-text" hidden="true">This is a simple gecko example. It has support for lots of things that browsers have, from html to (some parts of) webextensions</description>
-</html:body>
+  <html:body
+    xmlns="http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul"
+  >
+    <description>Hello World</description>
+    <separator />
+    <button id="show-more" label="More >>" oncommand="showMore()" />
+    <button
+      id="start-devtools"
+      label="Start Devtools"
+      oncommand="startDevtools()"
+    />
+    <separator />
+    <description id="more-text" hidden="true"
+      >This is a simple gecko example. It has support for lots of things that
+      browsers have, from html to (some parts of) webextensions</description
+    >
+
+    <html:div id="devtools-instructions" hidden="true">
+      <html:h2>To connect to the devtools server:</html:h2>
+      <html:ol>
+        <html:li>Open 'about:debugging' in Firefox or Pulse Browser</html:li>
+        <html:li>Open the setup tab</html:li>
+        <html:li
+          >Enter the following host inside of network locations
+          'localhost:<html:span id="devtools-port"></html:span>' and click
+          'Add'</html:li
+        >
+        <html:li>Click 'Connect' in the left sidebar</html:li>
+        <html:li>Click on the entry in the left sidebar</html:li>
+        <html:li>Click 'Open in Browser Toolbox'</html:li>
+      </html:ol>
+    </html:div>
+  </html:body>
 </html>

--- a/boilerplate/frontend/jar.mn
+++ b/boilerplate/frontend/jar.mn
@@ -1,10 +1,14 @@
+#filter substitution
 
 newapp.jar:
 % content newapp %content/ contentaccessible=yes
   content/main.xhtml                  (content/main.xhtml)
   content/main.js                     (content/main.js)
 
-branding.jar:
-% locale branding en-US branding/en-US/
+[localization] @AB_CD@.jar:
+  branding                                          (en-US/**/*.ftl)
+
+@AB_CD@.jar:
+% locale branding @AB_CD@ %locale/branding/
   locale/branding/brand.dtd        (branding/en-US/brand.dtd)
   locale/branding/brand.properties (branding/en-US/brand.properties)

--- a/boilerplate/modules/DevtoolsServer.jsm
+++ b/boilerplate/modules/DevtoolsServer.jsm
@@ -64,8 +64,12 @@ class DevtoolsServer {
     const socketOptions = {
       portOrPath: serverPort,
     };
-    this.listener = new SocketListener(this.devToolsServer, socketOptions);
-    this.listener.open();
+
+    /**
+     * @protected
+     */
+    this._listener = new SocketListener(this.devToolsServer, socketOptions);
+    this._listener.open();
 
     if (!this.silent) {
       dump(`Devtools opened on port ${this.port}`);
@@ -94,10 +98,10 @@ class DevtoolsServer {
    * @return {?number} The port the devtools server is listening on.
    */
   get port() {
-    if (!this.listener) {
+    if (!this._listener) {
       return;
     }
 
-    return this.listener.port;
+    return this._listener.port;
   }
 }

--- a/boilerplate/modules/DevtoolsServer.jsm
+++ b/boilerplate/modules/DevtoolsServer.jsm
@@ -8,7 +8,7 @@ const { useDistinctSystemPrincipalLoader } = ChromeUtils.import(
   "resource://devtools/shared/loader/Loader.jsm"
 );
 
-var EXPORTED_SYMBOLS = ["DevtoolsServer"];
+const EXPORTED_SYMBOLS = ["DevtoolsServer"];
 
 let singletonInstance;
 

--- a/boilerplate/modules/DevtoolsServer.jsm
+++ b/boilerplate/modules/DevtoolsServer.jsm
@@ -27,6 +27,19 @@ let singletonInstance;
  * 4. Click 'Connect' in the left sidebar
  * 5. Click on the entry in the left sidebar
  * 6. Click 'Open in Browser Toolbox'
+ *
+ * ## Usage
+ * ```js
+ * const { DevtoolsServer } = ChromeUtils.import("resource://app/modules/DevtoolsServer.jsm");
+ *
+ * const devtools = DevtoolsServer.get();
+ * devtools.start();
+ *
+ * const port = devtools.port;
+ * devtools.logInstructions();
+ *
+ * devtools.start(); // Will warn and do nothing
+ * ```
  */
 class DevtoolsServer {
   /**

--- a/boilerplate/modules/DevtoolsServer.jsm
+++ b/boilerplate/modules/DevtoolsServer.jsm
@@ -1,0 +1,103 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+"use strict";
+
+const { useDistinctSystemPrincipalLoader } = ChromeUtils.import(
+  "resource://devtools/shared/loader/Loader.jsm"
+);
+
+var EXPORTED_SYMBOLS = ["DevtoolsServer"];
+
+/**
+ * Opens a devtool server that can be inspected using Firefox's devtools.
+ *
+ * The port can be set either by passing it in to the function or setting the
+ * appropriate preference value. If there is no port value provided, Gecko will
+ * find a free port and use it instead
+ *
+ * To connect to the devtools server:
+ * 1. Open 'about:debugging' in Firefox or Pulse Browser
+ * 2. Open the setup tab
+ * 3. Enter the following host inside of network locations 'localhost:${listener.port}' and click 'Add'
+ * 4. Click 'Connect' in the left sidebar
+ * 5. Click on the entry in the left sidebar
+ * 6. Click 'Open in Browser Toolbox'
+ */
+class DevtoolsServer {
+  /**
+   * @param {?number} port The port you want to open the devtools on.
+   * @param {?boolean} silent If true, instructions will not be logged to the console.
+   */
+  constructor(port, silent) {
+    this.defaultPort = port;
+    this.silent = silent || false;
+
+    this.loader = useDistinctSystemPrincipalLoader(this);
+  }
+
+  /**
+   * Starts the devtools server.
+   * @returns {DevtoolsServer}
+   */
+  start() {
+    const { DevToolsServer } = this.loader.require(
+      "devtools/server/devtools-server"
+    );
+    const { SocketListener } = this.loader.require(
+      "devtools/shared/security/socket"
+    );
+
+    this.devToolsServer = DevToolsServer;
+
+    this.devToolsServer.init();
+    // We mainly need a root actor and target actors for opening a toolbox, even
+    // against chrome/content. But the "no auto hide" button uses the
+    // preference actor, so also register the browser actors.
+    this.devToolsServer.registerAllActors();
+    this.devToolsServer.allowChromeProcess = true;
+
+    const serverPort =
+      this.defaultPort ||
+      Services.prefs.getIntPref("devtools.debugger.server-port", -1);
+    const socketOptions = {
+      portOrPath: serverPort,
+    };
+    this.listener = new SocketListener(this.devToolsServer, socketOptions);
+    this.listener.open();
+
+    if (!this.silent) {
+      dump(`Devtools opened on port ${this.port}`);
+      this.logInstructions();
+    }
+
+    return this;
+  }
+
+  logInstructions() {
+    dump(`
+    To connect to the devtools server:
+    1. Open 'about:debugging' in Firefox or Pulse Browser
+    2. Open the setup tab
+    3. Enter the following host inside of network locations 'localhost:${this.port}' and click 'Add'
+    4. Click 'Connect' in the left sidebar
+    5. Click on the entry in the left sidebar
+    6. Click 'Open in Browser Toolbox'
+`);
+  }
+
+  /**
+   * Returns the port the devtools server is listening on. This will return
+   * undefined if the server has not been started
+   *
+   * @return {?number} The port the devtools server is listening on.
+   */
+  get port() {
+    if (!this.listener) {
+      return;
+    }
+
+    return this.listener.port;
+  }
+}

--- a/boilerplate/modules/DevtoolsServer.jsm
+++ b/boilerplate/modules/DevtoolsServer.jsm
@@ -27,8 +27,8 @@ var EXPORTED_SYMBOLS = ["DevtoolsServer"];
  */
 class DevtoolsServer {
   /**
-   * @param {?number} port The port you want to open the devtools on.
-   * @param {?boolean} silent If true, instructions will not be logged to the console.
+   * @param {number} [port] The port you want to open the devtools on.
+   * @param {boolean} [silent] If true, instructions will not be logged to the console.
    */
   constructor(port, silent) {
     this.defaultPort = port;

--- a/boilerplate/modules/moz.build
+++ b/boilerplate/modules/moz.build
@@ -1,0 +1,7 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+EXTRA_JS_MODULES += [
+    "DevtoolsServer.jsm",
+]

--- a/boilerplate/moz.build
+++ b/boilerplate/moz.build
@@ -5,7 +5,8 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 DIRS += [
-  "frontend"
+  "frontend",
+  "modules"
 ]
 
 # The firefox setup does not allow for any imports after app on MacOS. Not sure 


### PR DESCRIPTION
Aside from the formatting changes, this pull request provides a simplified module for starting a devtool server, which can be connected to via a Firefox instance. Most of this code is based on [`Launcher.jsm`](https://searchfox.org/mozilla-central/source/devtools/client/framework/browser-toolbox/Launcher.jsm), however we cannot directly use it, as it will try and launch a devtool window, which behaves erratically. 


## Assorted tangents
The `-chrome` option used by `Launcher.jsm` doesn't work with apps that use `toolkit.defaultChromeURI` to specify their URL. If someone ever needs to get that to work and stumbles across this, you need to patch [`DefaultCLH.jsm`](https://searchfox.org/mozilla-central/source/toolkit/components/DefaultCLH.jsm) to contain something like this:

```
const chromeFlagURI = cmdLine.handleFlagWithParam("chrome", false);

if (chromeFlagURI) {
  try {
    const flags = prefs.getCharPref(
      "toolkit.defaultChromeFeatures",
      "chrome,dialog=no,all"
    );

    const wwatch = Cc["@mozilla.org/embedcomp/window-watcher;1"].getService(
      nsIWindowWatcher
    );
    wwatch.openWindow(null, chromeFlagURI, "_blank", flags, cmdLine);
  } catch (e) {
    console.warn("Failed to open chrome URL: " + chromeFlagURI);
    console.warn(e);
  }

  return;
}
```